### PR TITLE
Adding the directory extraction convenience script

### DIFF
--- a/DmpWorkflow/utils/copyWorkingDirectoryFromInstance.py
+++ b/DmpWorkflow/utils/copyWorkingDirectoryFromInstance.py
@@ -3,7 +3,7 @@
 # call: python script.py -t JobName -i instanceId -o OutputDir
 #
 from copy import deepcopy
-from os import curdir, mkdir, system
+from os import curdir, mkdir, system, getcwd
 from os.path import abspath,isdir
 from sys import argv
 from argparse import ArgumentParser
@@ -44,8 +44,13 @@ def main(args=None):
   #if not opts.output is None:
   #  outdir=opts.output
   #if not isdir(outdir): mkdir(outdir) 
-  xrd_files="xrdfs xrootd-dampe.cloud.ba.infn.it ls -u /UserSpace/dampe_prod/mc/workdir/{site}/{task}/{task_type}/{sixDigit} 2> /dev/null".format(site=opts.site, task=opts.task, sixDigit=getSixDigits(opts.inst_id,asPath=True),task_type=opts.task_type)
-  xrd_cmd="{list} | xargs -I @ xrdcp @ {task}/{inst}/.".format(list=xrd_files,inst=opts.inst_id,task=opts.task)
+  if site == 'CSCS':
+	xrd_cmd = "globus-url-copy -r -sync -q -rst sshftp://stzimmer@gridftp.cscs.ch/scratch/snx3000/stzimmer/mc/workdir/{site}/{task}/{task_type}/{sixDigit} file://{cwd}/{task}/{inst}/. 2> /dev/null".format(site=opts.site, task=opts.task, sixDigit=getSixDigits(opts.inst_id,asPath=True),task_type=opts.task_type,cwd=getcwd())
+	# r: recursive ; sync: no copy if file already exists; q: quiet mode; rst: restart if failed, up to 5 times
+  else:
+    xrd_files="xrdfs xrootd-dampe.cloud.ba.infn.it ls -u /UserSpace/dampe_prod/mc/workdir/{site}/{task}/{task_type}/{sixDigit} 2> /dev/null".format(site=opts.site, task=opts.task, sixDigit=getSixDigits(opts.inst_id,asPath=True),task_type=opts.task_type)
+    xrd_cmd="{list} | xargs -I @ xrdcp @ {task}/{inst}/.".format(list=xrd_files,inst=opts.inst_id,task=opts.task)
+  
   mkcmd="mkdir -pv {task}/{inst}".format(task=opts.task,inst=opts.inst_id)
   print mkcmd
   print xrd_cmd

--- a/DmpWorkflow/utils/copyWorkingDirectoryFromInstance.py
+++ b/DmpWorkflow/utils/copyWorkingDirectoryFromInstance.py
@@ -8,28 +8,8 @@ from os.path import abspath,isdir
 from sys import argv
 from argparse import ArgumentParser
 from yaml import load as yload
+from DmpWorkflow.utils.tools import getSixDigits
 
-def getSixDigits(number, asPath=False):
-  """ since we can have many many streams, break things up into chunks, 
-      this should make sure that 'ls' is not too slow. """
-  if not asPath:
-     return str(number).zfill(6)
-  else:
-     if number < 100:
-        return str(number).zfill(2)
-     else:
-          my_path = []
-          rest = deepcopy(number)
-          blocks = [100000, 10000, 1000, 100]
-          for b in blocks:
-              value, rest = divmod(rest, b)
-              # print b, value, rest
-              if value:
-                padding = "".ljust(len(str(b)) - 1, "x")
-                my_path.append("%i%s" % (value, padding))
-                rest = rest
-          my_path.append(str(rest).zfill(2))
-          return "/".join([str(s) for s in my_path])
 
 def main(args=None):
   usage = "Usage: %(prog)s [options]"
@@ -55,10 +35,7 @@ def main(args=None):
 	gridftp_path = parameters['path']
 	xrd_cmd = "globus-url-copy -r -sync -q -rst {prtcl}://{usr}@{url}{remotepath}/{wdpath}/{site}/{task}/{task_type}/{sixDigit} file://{cwd}/{task}/{inst}/. 2> /dev/null".format(prtcl=gridftp_protocol, usr=gridftp_user,
 																																									url=gridftp_URL, remotepath=gridftp_path,
-																																									wdpath=opts.wdpth, site=opts.site,
-																																									task=opts.task, task_type=opts.task_type,
-																																									sixDigit=getSixDigits(opts.inst_id,asPath=True),
-																																									cwd=getcwd(),inst=opts.inst_id)
+																																									wdpath=opts.wdpth, site=opts.site,																																					cwd=getcwd(),inst=opts.inst_id)
 	# r: recursive ; sync: no copy if file already exists; q: quiet mode; rst: restart if failed, up to 5 times
   
   else:
@@ -70,10 +47,6 @@ def main(args=None):
   print xrd_cmd
 
 
-
-
-
-  pass
 
 if __name__ == '__main__':
   main()

--- a/DmpWorkflow/utils/copyWorkingDirectoryFromInstance.py
+++ b/DmpWorkflow/utils/copyWorkingDirectoryFromInstance.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+## convenience script to extract JobDirectory and copy to local space
+# call: python script.py -t JobName -i instanceId -o OutputDir
+#
+from copy import deepcopy
+from os import curdir, mkdir, system
+from os.path import abspath,isdir
+from sys import argv
+from argparse import ArgumentParser
+
+def getSixDigits(number, asPath=False):
+  """ since we can have many many streams, break things up into chunks, 
+      this should make sure that 'ls' is not too slow. """
+  if not asPath:
+     return str(number).zfill(6)
+  else:
+     if number < 100:
+        return str(number).zfill(2)
+     else:
+          my_path = []
+          rest = deepcopy(number)
+          blocks = [100000, 10000, 1000, 100]
+          for b in blocks:
+              value, rest = divmod(rest, b)
+              # print b, value, rest
+              if value:
+                padding = "".ljust(len(str(b)) - 1, "x")
+                my_path.append("%i%s" % (value, padding))
+                rest = rest
+          my_path.append(str(rest).zfill(2))
+          return "/".join([str(s) for s in my_path])
+
+def main(args=None):
+  usage = "Usage: %(prog)s [options]"
+  description = "extract Working Directory based on JobName & Instance Id"
+  parser = ArgumentParser(usage=usage, description=description)
+  parser.add_argument("--job","-j", dest='task', help="name of job",required=True)
+  parser.add_argument("--type","-t", dest="task_type", help="type of task, Simulation is default", default="Simulation")
+  parser.add_argument("--site","-s", dest='site', default="BARI", help="Name of site the job was running at")
+  parser.add_argument("--inst_id","-i", dest='inst_id', help="Instance ID", type=int,required=True)
+  #parser.add_argument("--output","-o",dest='output',help='output directory, if not set, will create directory here',default=None)
+  opts = parser.parse_args(args)
+  #outdir=abspath(curdir)
+  #if not opts.output is None:
+  #  outdir=opts.output
+  #if not isdir(outdir): mkdir(outdir) 
+  xrd_files="xrdfs xrootd-dampe.cloud.ba.infn.it ls -u /UserSpace/dampe_prod/mc/workdir/{site}/{task}/{task_type}/{sixDigit} 2> /dev/null".format(site=opts.site, task=opts.task, sixDigit=getSixDigits(opts.inst_id,asPath=True),task_type=opts.task_type)
+  xrd_cmd="{list} | xargs -I @ xrdcp @ {task}/{inst}/.".format(list=xrd_files,inst=opts.inst_id,task=opts.task)
+  mkcmd="mkdir -pv {task}/{inst}".format(task=opts.task,inst=opts.inst_id)
+  print mkcmd
+  print xrd_cmd
+
+
+
+
+
+  pass
+
+if __name__ == '__main__':
+  main()

--- a/DmpWorkflow/utils/copyWorkingDirectoryFromInstance.py
+++ b/DmpWorkflow/utils/copyWorkingDirectoryFromInstance.py
@@ -38,6 +38,8 @@ def main(args=None):
   parser.add_argument("--type","-t", dest="task_type", help="type of task, Simulation is default", default="Simulation")
   parser.add_argument("--site","-s", dest='site', default="BARI", help="Name of site the job was running at")
   parser.add_argument("--inst_id","-i", dest='inst_id', help="Instance ID", type=int,required=True)
+  parser.add_argument("--workdir_path", dest='wdpth', default="mc/workdir",help="Path of working directory in remote location")
+  parser.add_argument("--gridftp_path", dest='rmtpth', default='stzimmer@gridftp.cscs.ch/scratch/snx3000/stzimmer',help="Full path for gridFTP transfer")
   #parser.add_argument("--output","-o",dest='output',help='output directory, if not set, will create directory here',default=None)
   opts = parser.parse_args(args)
   #outdir=abspath(curdir)
@@ -45,10 +47,14 @@ def main(args=None):
   #  outdir=opts.output
   #if not isdir(outdir): mkdir(outdir) 
   if site == 'CSCS':
-	xrd_cmd = "globus-url-copy -r -sync -q -rst sshftp://stzimmer@gridftp.cscs.ch/scratch/snx3000/stzimmer/mc/workdir/{site}/{task}/{task_type}/{sixDigit} file://{cwd}/{task}/{inst}/. 2> /dev/null".format(site=opts.site, task=opts.task, sixDigit=getSixDigits(opts.inst_id,asPath=True),task_type=opts.task_type,cwd=getcwd())
+	xrd_cmd = "globus-url-copy -r -sync -q -rst sshftp://{remotepath}/{wdpath}/{site}/{task}/{task_type}/{sixDigit} file://{cwd}/{task}/{inst}/. 2> /dev/null".format(site=opts.site, task=opts.task, 
+																																									sixDigit=getSixDigits(opts.inst_id,asPath=True),
+																																									task_type=opts.task_type, cwd=getcwd(),
+																																									wdpath=opts.wdpth, remotepath=opt.rmtpth)
 	# r: recursive ; sync: no copy if file already exists; q: quiet mode; rst: restart if failed, up to 5 times
+  
   else:
-    xrd_files="xrdfs xrootd-dampe.cloud.ba.infn.it ls -u /UserSpace/dampe_prod/mc/workdir/{site}/{task}/{task_type}/{sixDigit} 2> /dev/null".format(site=opts.site, task=opts.task, sixDigit=getSixDigits(opts.inst_id,asPath=True),task_type=opts.task_type)
+    xrd_files="xrdfs xrootd-dampe.cloud.ba.infn.it ls -u /UserSpace/dampe_prod/{wdpath}/{site}/{task}/{task_type}/{sixDigit} 2> /dev/null".format(site=opts.site, task=opts.task, sixDigit=getSixDigits(opts.inst_id,asPath=True),task_type=opts.task_type,wdpath=opts.wdpth)
     xrd_cmd="{list} | xargs -I @ xrdcp @ {task}/{inst}/.".format(list=xrd_files,inst=opts.inst_id,task=opts.task)
   
   mkcmd="mkdir -pv {task}/{inst}".format(task=opts.task,inst=opts.inst_id)


### PR DESCRIPTION
Commit 1 : Original script as written by @zimmerst 

Commit 2 : Add support for CSCS infrastructure. Specifics: Rely on a gridFTP transfer instead of XRootD. Need the globus client tools installed to use the script output. Fetches CSCS data from a very specific path. 